### PR TITLE
fix component decorator;

### DIFF
--- a/src/main/ES/annotations/component.js
+++ b/src/main/ES/annotations/component.js
@@ -22,7 +22,7 @@ function Component(selector) {
 	function annotate(target, selector) {
 		angular
 			.module(target.moduleName)
-			.component(pascalCaseToCamelCase(selector || target.name), () => new target());
+			.component(pascalCaseToCamelCase(selector || target.name), new target());
 	}
 }
 


### PR DESCRIPTION
Component method unlike the .directive() method, does not take a factory function.